### PR TITLE
Kernel cout

### DIFF
--- a/include/drivers/vga.hpp
+++ b/include/drivers/vga.hpp
@@ -3,7 +3,7 @@
 #include <stl/cstdlib/cstdint.h>
 #include <stl/cstdlib/cstring.h>
 
-namespace firefly::drivers::vga {     
+namespace firefly::drivers::vga {
 /**
  *                          A VGA color
  */

--- a/include/init/init.hpp
+++ b/include/init/init.hpp
@@ -2,5 +2,5 @@
 #include <cstdlib/cstdint.h>
 
 namespace firefly::kernel {
-    void kernel_init(uint64_t *mb2_struct_address);
+    void kernel_init(uint64_t mb2_struct_address);
 }

--- a/include/init/mb2_proto.hpp
+++ b/include/init/mb2_proto.hpp
@@ -3,5 +3,5 @@
 #include <cstdlib/cstdint.h>
 
 namespace firefly::kernel::mb2proto {
-    void init(uint64_t *mb2_struct_address);
+    void init(uint64_t mb2_struct_address);
 }

--- a/include/kernel.hpp
+++ b/include/kernel.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <drivers/vga.hpp>
-
-namespace firefly::kernel::main {
-firefly::drivers::vga::cursor &get_cursor();
-}

--- a/include/libk++/ios.h
+++ b/include/libk++/ios.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "cstdlib/cstdint.h"
+#include "cstdlib/stdio.h"
+
+namespace firefly::libkern {
+char buff[20];
+char* hex(int n) {
+    return itoa(n, buff, 16);
+}
+
+char* dec(int n) {
+    return itoa(n, buff, 10);
+}
+}  // namespace firefly::libkern

--- a/include/libk++/iostream.h
+++ b/include/libk++/iostream.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <drivers/vga.hpp>
+
+namespace firefly::libkern {
+using namespace firefly::drivers::vga;
+
+/* This allows the kernel to get a global reference to the cursor object */
+static firefly::drivers::vga::cursor cout;
+const char endl = '\n';
+
+inline firefly::drivers::vga::cursor& get_cursor_handle() {
+    return cout;
+}
+
+inline void globalize_vga_writer() {
+    drivers::vga::cursor crs = { color::white, color::black, 0, 0 };
+    cout = crs;
+}
+
+template <typename... Tys>
+void print(Tys... args) {
+    ((cout << args << ' '), ...);
+    cout << endl;
+}
+
+}  // namespace firefly::libkern

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,7 +1,6 @@
 #pragma once
-#include "drivers/vga.hpp"
+#include <drivers/vga.hpp>
 
 namespace firefly::kernel {
-void start_load(const char* _str);
-void end_load(const char* _str);
+
 }  // namespace firefly::kernel

--- a/kernel/init/init.cpp
+++ b/kernel/init/init.cpp
@@ -1,15 +1,11 @@
+#include <stl/iostream.h>
+
 #include <drivers/vga.hpp>
 #include <init/init.hpp>
 #include <init/mb2_proto.hpp>
-#include <kernel.hpp>
 
 namespace firefly::kernel {
-void kernel_init([[maybe_unused]]uint64_t *mb2_struct_address) {
-    using firefly::drivers::vga::color;
-    using firefly::drivers::vga::cursor;
-    
-    cursor& crs = kernel::main::get_cursor();
-    crs << "Testing globalized vga writer...\n";
+void kernel_init([[maybe_unused]] uint64_t *mb2_struct_address) {
     mb2proto::init(mb2_struct_address);
 }
 }  // namespace firefly::kernel

--- a/kernel/init/init.cpp
+++ b/kernel/init/init.cpp
@@ -1,11 +1,11 @@
-#include <stl/iostream.h>
+#include <libk++/iostream.h>
 
 #include <drivers/vga.hpp>
 #include <init/init.hpp>
 #include <init/mb2_proto.hpp>
 
 namespace firefly::kernel {
-void kernel_init([[maybe_unused]] uint64_t *mb2_struct_address) {
+void kernel_init([[maybe_unused]] uint64_t mb2_struct_address) {
     mb2proto::init(mb2_struct_address);
 }
 }  // namespace firefly::kernel

--- a/kernel/init/mb2_proto.cpp
+++ b/kernel/init/mb2_proto.cpp
@@ -1,6 +1,6 @@
 #include <init/mb2_proto.hpp>
 
 namespace firefly::kernel::mb2proto {
-    void init([[maybe_unused]] uint64_t* mb2_struct_address) {
-    }
+void init([[maybe_unused]] uint64_t mb2_struct_address) {
+}
 }  // namespace firefly::kernel::mb2proto

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -1,7 +1,7 @@
 #include <cstdlib/stdio.h>
+#include <libk++/ios.h>
+#include <libk++/iostream.h>
 #include <stl/array.h>
-#include <stl/ios.h>
-#include <stl/iostream.h>
 
 #include <drivers/ps2.hpp>
 #include <drivers/vga.hpp>
@@ -18,7 +18,7 @@ void write_ff_info() {
     using firefly::drivers::vga::clear;
     clear();
 
-    firefly::std::cout << "FireflyOS\nVersion: " << VERSION_STRING << "\nContributors:";
+    firefly::libkern::cout << "FireflyOS\nVersion: " << VERSION_STRING << "\nContributors:";
 
     firefly::std::array<const char *, 3> arr = {
         "Lime\t  ", "JohnkaS", "V01D-NULL"
@@ -26,33 +26,34 @@ void write_ff_info() {
 
     for (size_t i = 0; i < arr.max_size(); i++) {
         if (i % 2 == 0) {
-            firefly::std::cout << "\n\t";
+            firefly::libkern::cout << "\n\t";
         }
-        firefly::std::cout << arr[i] << "  ";
+        firefly::libkern::cout << arr[i] << "  ";
     }
-    firefly::std::cout << "\n";
+    firefly::libkern::cout << "\n";
 }
 }  // namespace firefly::kernel::main
 
-extern "C" [[noreturn]] void kernel_main(uint64_t *mb2_proto_struct) {
+extern "C" [[noreturn]] void kernel_main(uint64_t mb2_proto_struct) {
     using firefly::drivers::vga::color;
     using firefly::drivers::vga::cursor;
 
     firefly::drivers::vga::init();
-    firefly::std::globalize_vga_writer();
+    firefly::libkern::globalize_vga_writer();
     firefly::kernel::main::write_ff_info();
     firefly::drivers::ps2::init();
     firefly::kernel::interrupt::init();
     firefly::kernel::kernel_init(mb2_proto_struct);
 
-    firefly::std::cout << "Hello world! This is a number: " << 534982 << firefly::std::endl;
-    firefly::std::cout << firefly::std::hex(0xF123) << firefly::std::endl;
+    firefly::libkern::cout << "Hello, world!" << firefly::libkern::endl;
+    //Note: Once the strrev fix has been pushed this can be used reliably
+    // firefly::libkern::print("MB2 struct @ ", firefly::libkern::hex(mb2_proto_struct-0xFFFFFFFF80000000));
 
     while (true) {
         auto key = firefly::drivers::ps2::get_scancode();
         if (!key.has_value()) {
             continue;
         }
-        firefly::drivers::ps2::handle_input(*key, firefly::std::get_cursor_handle());
+        firefly::drivers::ps2::handle_input(*key, firefly::libkern::get_cursor_handle());
     }
 }

--- a/kernel/utils.cpp
+++ b/kernel/utils.cpp
@@ -1,27 +1,8 @@
-#include "utils.hpp"
-
+#include <stl/iostream.h>
 #include <stl/utility.h>
 
-#include <kernel.hpp>
+#include <utils.hpp>
 
-namespace firefly::kernel {
-using namespace firefly::drivers::vga;
-void start_load(const char* _str) {
-    cursor& crs = kernel::main::get_cursor();
-    crs << "[";
-    crs.set_foreground_color(color::blue);
-    crs << "START";
-    crs.set_foreground_color(color::white);
-    crs << "]" << _str << "\n";
-}
+namespace firefly::kernel::util {
 
-void end_load(const char* _str) {
-    cursor& crs = kernel::main::get_cursor();
-    // cursor& crs = get_cursor();
-    crs << "[";
-    crs.set_foreground_color(color::green);
-    crs << "OK";
-    crs.set_foreground_color(color::white);
-    crs << "]" << _str << "\n";
-}
-}  // namespace firefly::kernel
+}  // namespace firefly::kernel::util

--- a/kernel/utils.cpp
+++ b/kernel/utils.cpp
@@ -1,4 +1,4 @@
-#include <stl/iostream.h>
+#include <libk++/iostream.h>
 #include <stl/utility.h>
 
 #include <utils.hpp>


### PR DESCRIPTION
Added a simple wrapper for vga in `include/libk++/` (namespace: `firefly::libkern`)
This wrapper can be updated to switch from vga to vbe with minimal efforts.

Most of these functions aren't conform with your known C++ stl, but that is the reason why I embedded it in the kernel instead of firefly's STL