### PR TITLE
i386 = x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ifeq ($(ARCH), x86_64)
 endif
 ifeq ($(ARCH), i386)
 	mkdir -vp $(BUILD_DIR)/arch/$(ARCH)/kernel/drivers
+	mkdir -vp $(BUILD_DIR)/arch/$(ARCH)/kernel/trace
 	mkdir -vp $(BUILD_DIR)/arch/$(ARCH)/kernel/init
 	mkdir -vp $(BUILD_DIR)/arch/$(ARCH)/kernel/int
 	mkdir -vp $(BUILD_DIR)/arch/$(ARCH)/libk++

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: create_dirs $(TARGET)
 
 $(TARGET): $(CONV_FILES)
 	$(MAKE) -C ./include/stl # Build STL before linking
-	ld -o $@ --no-undefined -T linkage/linker_$(ARCH).ld -nostdlib -m elf_$(ARCH) $(OBJ_FILES) $(LIB_OBJS) 
+	ld.lld -o $@ --no-undefined -T linkage/linker_$(ARCH).ld -nostdlib -m elf_$(ARCH) $(OBJ_FILES) $(LIB_OBJS) 
 	cp linkage/multi_arch_grub/grub.$(ARCH) binaries/boot/grub/grub.cfg
 	grub-mkrescue -o FireflyOS_$(ARCH).iso binaries
 	

--- a/arch/i386/kernel/drivers/vga.cpp
+++ b/arch/i386/kernel/drivers/vga.cpp
@@ -12,6 +12,7 @@ vga_char cursor::character(char c) {
     return { c, fg, bg };
 }
 
+#pragma region Operator type overrides
 cursor& cursor::operator<<(const char* c) {
     write(c, *this);
     return *this;
@@ -27,6 +28,26 @@ cursor& cursor::operator<<(int n) {
     itoa(n, buffer, 10);
     return (*this) << buffer;
 }
+
+cursor& cursor::operator<<(short n) {
+    char buffer[10];
+    itoa(n, buffer, 10);
+    return (*this) << buffer;
+}
+
+cursor& cursor::operator<<(long n) {
+    char buffer[10];
+    itoa(n, buffer, 10);
+    return (*this) << buffer;
+}
+
+cursor& cursor::operator<<(unsigned n) {
+    char buffer[10];
+    itoa(n, buffer, 10);
+    return (*this) << buffer;
+}
+
+#pragma endregion
 
 void cursor::set_foreground_color(color c) {
     fg = c;

--- a/arch/i386/kernel/drivers/vga.cpp
+++ b/arch/i386/kernel/drivers/vga.cpp
@@ -23,29 +23,29 @@ cursor& cursor::operator<<(char c) {
     return *this;
 }
 
-cursor& cursor::operator<<(int n) {
+cursor& cursor::operator<<(size_t n) {
     char buffer[10];
     itoa(n, buffer, 10);
     return (*this) << buffer;
 }
 
-cursor& cursor::operator<<(short n) {
-    char buffer[10];
-    itoa(n, buffer, 10);
-    return (*this) << buffer;
-}
+// cursor& cursor::operator<<(short n) {
+//     char buffer[10];
+//     itoa(n, buffer, 10);
+//     return (*this) << buffer;
+// }
 
-cursor& cursor::operator<<(long n) {
-    char buffer[10];
-    itoa(n, buffer, 10);
-    return (*this) << buffer;
-}
+// cursor& cursor::operator<<(long n) {
+//     char buffer[10];
+//     itoa(n, buffer, 10);
+//     return (*this) << buffer;
+// }
 
-cursor& cursor::operator<<(unsigned n) {
-    char buffer[10];
-    itoa(n, buffer, 10);
-    return (*this) << buffer;
-}
+// cursor& cursor::operator<<(unsigned n) {
+//     char buffer[10];
+//     itoa(n, buffer, 10);
+//     return (*this) << buffer;
+// }
 
 #pragma endregion
 

--- a/arch/i386/kernel/init/mb2_proto.cpp
+++ b/arch/i386/kernel/init/mb2_proto.cpp
@@ -1,13 +1,34 @@
 #include <i386/libk++/iostream.h>
 
 #include <i386/init/mb2_proto.hpp>
+#include <i386/trace/strace.hpp>
 
 namespace firefly::kernel::mb2proto {
 void init(mboot_param magic, [[maybe_unused]] mboot_param mb2_struct_address) {
+    /* Verify magic and alignment */
     if (magic != MULTIBOOT2_BOOTLOADER_MAGIC) {
-        klog("Invalid magic!\n");
-    } else {
-        klog("Magic is valid\n");
+        panic("Invalid magic!\n");
     }
+    klog("Magic is valid\n");
+
+    if (mb2_struct_address & 7) {
+        panic("Unaligned multiboot2 struct!\n");
+    }
+    klog("Multiboot2 struct is aligned\n");
+
+    unsigned size;
+    size = *(unsigned *)mb2_struct_address;
+    struct multiboot_tag *tag;
+    klog("MBI Size: " << size << libkern::endl);
+
+    for (tag = (struct multiboot_tag *)(mb2_struct_address + 8);
+         tag->type != MULTIBOOT_TAG_TYPE_END;
+         tag = (struct multiboot_tag *)((multiboot_uint8_t *)tag + ((tag->size + 7) & ~7))) {
+        if (tag->type == MULTIBOOT_TAG_TYPE_CMDLINE)
+        {
+            klog("cmdline tag " << ((struct multiboot_tag_string*) tag)->string << "\n");
+        }
+    }
+    klog("ok");
 }
 }  // namespace firefly::kernel::mb2proto

--- a/arch/i386/kernel/init/mb2_proto.cpp
+++ b/arch/i386/kernel/init/mb2_proto.cpp
@@ -1,4 +1,5 @@
 #include <i386/libk++/iostream.h>
+#include <stl/cstdlib/stdio.h>
 
 #include <i386/init/mb2_proto.hpp>
 #include <i386/trace/strace.hpp>
@@ -19,16 +20,12 @@ void init(mboot_param magic, [[maybe_unused]] mboot_param mb2_struct_address) {
     unsigned size;
     size = *(unsigned *)mb2_struct_address;
     struct multiboot_tag *tag;
-    klog("MBI Size: " << size << libkern::endl);
+    printf("MBI Size: %d\n", size);
 
     for (tag = (struct multiboot_tag *)(mb2_struct_address + 8);
          tag->type != MULTIBOOT_TAG_TYPE_END;
          tag = (struct multiboot_tag *)((multiboot_uint8_t *)tag + ((tag->size + 7) & ~7))) {
-        if (tag->type == MULTIBOOT_TAG_TYPE_CMDLINE)
-        {
-            klog("cmdline tag " << ((struct multiboot_tag_string*) tag)->string << "\n");
-        }
+        printf("Type: %d | Size: %d\n", tag->type, tag->size);
     }
-    klog("ok");
 }
 }  // namespace firefly::kernel::mb2proto

--- a/arch/i386/kernel/int/interrupt.asm
+++ b/arch/i386/kernel/int/interrupt.asm
@@ -1,0 +1,29 @@
+; bits 32
+
+; global interrupt_wrapper
+; global exception_wrapper
+
+; extern interrupt_handler
+; extern exception_handler
+
+
+; ; interrupt_wrapper:
+; ;     pusha
+; ;     ; also save SSE state when we figure that out
+        
+; ;     call interrupt_handler
+
+; ;     popa
+; ;     iret
+
+; exception_wrapper:
+;     pusha
+;     ; also save SSE state when we figure that out
+
+;     ; pass error code
+;     push dword [esp + (13 * 8)]
+;     call exception_handler
+
+;     popa
+;     iret
+

--- a/arch/i386/kernel/int/interrupt.cpp
+++ b/arch/i386/kernel/int/interrupt.cpp
@@ -1,0 +1,94 @@
+#include <i386/libk++/ios.h>
+#include <i386/libk++/iostream.h>
+
+#include <i386/drivers/vga.hpp>
+
+using namespace firefly::drivers::vga;
+
+namespace firefly::kernel::core::interrupt {
+struct __attribute__((packed)) idt_gate {
+    uint16_t offset_0;
+    uint16_t selector;
+    uint8_t rsv_0;
+    uint8_t type;
+    uint16_t offset_1;
+};
+static_assert(8 == sizeof(idt_gate), "idt_gate size incorrect");
+
+struct __attribute__((packed)) iframe {
+    uint32_t eip;
+    uint32_t cs;
+    uint32_t eflags;
+    uint32_t esp;
+    uint32_t ss;
+    uint32_t err;
+    uint32_t int_no;
+};
+
+__attribute__((interrupt)) __attribute__((noreturn)) void interrupt_wrapper([[maybe_unused]] iframe *iframe);
+__attribute__((interrupt)) __attribute__((noreturn)) void exception_wrapper([[maybe_unused]] iframe *iframe);
+
+idt_gate idt[256] = {};
+namespace change {
+void update(uint32_t handler, uint16_t cs, uint8_t type, uint8_t index) {
+    idt[index].offset_0 = handler & 0xffff;
+    idt[index].selector = cs;
+    idt[index].rsv_0 = 0;
+    idt[index].type = type;
+    idt[index].offset_1 = handler >> 16 & 0xffff;
+}
+
+//Hardcoded values as this is only meant for initialisation work by interrupt.cpp
+//Use the non-static version of "update" to update the idt at a global level
+static void initial_update(uint32_t handler, uint8_t index) {
+    change::update(handler, 0x10 /* CHANGE ME */, 0x8E, index);
+}
+
+}  // namespace change
+
+struct __attribute__((packed)) idt_reg {
+    /**
+         *                  size of table in bytes - 1
+         */
+    uint16_t limit;
+    /**
+         *                  base address of idt
+         */
+    uint32_t base;
+} idtr = {
+    .limit = (sizeof(struct idt_gate) * 256) - 1,
+    .base = (uint32_t)idt
+};
+
+
+void init() {
+    int i = 0;
+    for (; i <= 31; i++)
+        change::initial_update(reinterpret_cast<uint32_t>(interrupt_wrapper), i);
+    for (; i < 256; i++)
+        change::initial_update(reinterpret_cast<uint32_t>(exception_wrapper), i);
+
+    asm("lidt %0" ::"m"(idtr)
+        : "memory");
+}
+
+void test_int() {
+    klog("testing interrupt 0...\n");
+    asm volatile("int $0");
+}
+
+__attribute__((interrupt)) __attribute__((noreturn)) void interrupt_wrapper([[maybe_unused]] iframe *iframe) {
+    char buff[20];
+    klog("CPU exception caught (CS: 0x" << itoa(iframe->cs, buff, 16) << ")\n");
+
+    for (;;)
+        asm("cli;hlt");
+}
+
+__attribute__((interrupt)) __attribute__((noreturn)) void exception_wrapper([[maybe_unused]] iframe *iframe) {
+    // klog("An Interrupt has occurred: " << _iframe->cs);
+
+    for (;;)
+        asm("cli;hlt");
+}
+}  // namespace firefly::kernel::core::interrupt

--- a/arch/i386/kernel/int/interrupt.cpp
+++ b/arch/i386/kernel/int/interrupt.cpp
@@ -74,19 +74,23 @@ void init() {
 
 void test_int() {
     klog("testing interrupt 0...\n");
-    asm volatile("int $0");
+    asm volatile("int $80");
 }
 
 __attribute__((interrupt)) __attribute__((noreturn)) void interrupt_wrapper([[maybe_unused]] iframe *iframe) {
-    char buff[20];
-    klog("CPU exception caught (CS: 0x" << itoa(iframe->cs, buff, 16) << ")\n");
+    printf("CPU Exception caught\n CS: 0x%x\n", iframe->cs);
+    printf("EIP: %X\n", iframe->eip);
+    printf("ESP: %X\n", iframe->esp);
+
 
     for (;;)
         asm("cli;hlt");
 }
 
 __attribute__((interrupt)) __attribute__((noreturn)) void exception_wrapper([[maybe_unused]] iframe *iframe) {
-    // klog("An Interrupt has occurred: " << _iframe->cs);
+    printf("An external interrupt has occured\n CS: 0x%x\n", iframe->cs);
+    printf("EIP: %X\n", iframe->eip);
+    printf("ESP: %X\n", iframe->esp);
 
     for (;;)
         asm("cli;hlt");

--- a/arch/i386/kernel/kernel.cpp
+++ b/arch/i386/kernel/kernel.cpp
@@ -2,9 +2,11 @@
 #include <i386/libk++/iostream.h>
 #include <stdint.h>
 #include <stl/array.h>
+#include <stl/cstdlib/stdio.h>
 
 #include <i386/drivers/vga.hpp>
 #include <i386/init/init.hpp>
+#include <i386/int/interrupt.hpp>
 #include <i386/multiboot2.hpp>
 
 [[maybe_unused]] constexpr short MAJOR_VERSION = 0;
@@ -38,7 +40,7 @@ void write_ff_info() {
 }
 }  // namespace firefly::kernel::main
 
-extern "C" [[noreturn]] void kernel_main(mboot_param magic, [[maybe_unused]] mboot_param addr) {
+extern "C" [[noreturn]] void kernel_main([[maybe_unused]] mboot_param magic, [[maybe_unused]] mboot_param addr) {
     using firefly::drivers::vga::color;
     using firefly::drivers::vga::cursor;
 
@@ -46,7 +48,11 @@ extern "C" [[noreturn]] void kernel_main(mboot_param magic, [[maybe_unused]] mbo
     firefly::drivers::vga::cursor _cursor = { color::white, color::black, 0, 0 };
     firefly::kernel::main::cout = _cursor;
     firefly::kernel::main::write_ff_info();
-    firefly::kernel::kernel_init(magic, addr);
+    firefly::kernel::core::interrupt::init();
+
+    // firefly::kernel::core::interrupt::test_int();
+    printf("I love %c", 'C');
+    // firefly::kernel::kernel_init(magic, addr);
 
     while (1)
         ;

--- a/arch/i386/kernel/kernel.cpp
+++ b/arch/i386/kernel/kernel.cpp
@@ -40,6 +40,7 @@ void write_ff_info() {
 }
 }  // namespace firefly::kernel::main
 
+
 extern "C" [[noreturn]] void kernel_main([[maybe_unused]] mboot_param magic, [[maybe_unused]] mboot_param addr) {
     using firefly::drivers::vga::color;
     using firefly::drivers::vga::cursor;
@@ -49,11 +50,16 @@ extern "C" [[noreturn]] void kernel_main([[maybe_unused]] mboot_param magic, [[m
     firefly::kernel::main::cout = _cursor;
     firefly::kernel::main::write_ff_info();
     firefly::kernel::core::interrupt::init();
-
+    firefly::kernel::kernel_init(magic, addr);
     // firefly::kernel::core::interrupt::test_int();
-    printf("I love %c", 'C');
-    // firefly::kernel::kernel_init(magic, addr);
-
+    
+    //Printf test
+    int res = printf("Hex: %x\n", 0xabc);
+    printf("%d chars were written\n", res);
+    printf("Address of res is: %X\n", &res);
+    printf("octal: %o\n", 100);
+    printf("long hex: 0x%x\n", 0xabcdef12);
+    
     while (1)
         ;
 }

--- a/arch/i386/kernel/trace/strace.cpp
+++ b/arch/i386/kernel/trace/strace.cpp
@@ -1,0 +1,9 @@
+#include <i386/libk++/iostream.h>
+
+//TODO: Implement stack trace, that'll be for another time however
+void panic(const char *msg)
+{
+	klog(msg);	
+	while (1)
+		;
+}

--- a/arch/x86_64/kernel/boot.asm
+++ b/arch/x86_64/kernel/boot.asm
@@ -236,15 +236,6 @@ long_mode_start:
     lea rbx, [rel _init_array_end-8]
                                                 ; Since all of our code and data is within +/-2GiB
                                                 ; we can use a RIP relative instruction with disp32
-    jmp .getaddr
-.docall:
-    call r12
-.getaddr:
-    mov r12, [rbx]
-    sub rbx, 8
-    test r12, r12
-;    cmp r12, -1                                ; Should we be testing for 0 or -1?
-    jnz .docall
 
     cld
 

--- a/arch/x86_64/kernel/int/interrupt.cpp
+++ b/arch/x86_64/kernel/int/interrupt.cpp
@@ -111,76 +111,76 @@ static_assert(8 == sizeof(interrupt_error), "interrupt_error size incorrect");
 // static_assert(8 == sizeof(interrupt_frame, "interrupt_frame size incorrect"));
 
 namespace firefly::kernel::interrupt {
-    /**
+/**
      *                      the interrupt descriptor table
      */
-    namespace {
-        auto _inter = [](auto const& interrupt_wrapper) -> idt_gate {
-            return { static_cast<uint16_t>(reinterpret_cast<uint64_t>(interrupt_wrapper)), 8, 0, idt_gate::GATE_INTERRUPT, 0, 1,
-                     static_cast<uint16_t>(reinterpret_cast<uint64_t>(interrupt_wrapper) >> 16),
-                     static_cast<uint32_t>(reinterpret_cast<uint64_t>(interrupt_wrapper) >> 32), 0 };
-        };
-        auto __inter = _inter(interrupt_wrapper);
-    }  // namespace
+namespace {
+auto _inter = [](auto const& interrupt_wrapper) -> idt_gate {
+    return { static_cast<uint16_t>(reinterpret_cast<uint64_t>(interrupt_wrapper)), 8, 0, idt_gate::GATE_INTERRUPT, 0, 1,
+             static_cast<uint16_t>(reinterpret_cast<uint64_t>(interrupt_wrapper) >> 16),
+             static_cast<uint32_t>(reinterpret_cast<uint64_t>(interrupt_wrapper) >> 32), 0 };
+};
+auto __inter = _inter(interrupt_wrapper);
+}  // namespace
 
-    static firefly::std::array<idt_gate, 256> idt{
-        // up to int3
-        __inter, __inter, __inter, __inter
-        // all others have present flag set to 0
-    };
+static firefly::std::array<idt_gate, 256> idt{
+    // up to int3
+    __inter, __inter, __inter, __inter
+    // all others have present flag set to 0
+};
 
-    /**
+/**
      *                      contents to load into the idt register
      */
-    struct __attribute__((packed)) idt_reg {
-        /**
+struct __attribute__((packed)) idt_reg {
+    /**
          *                  size of table in bytes - 1
          */
-        uint16_t limit;
-        /**
+    uint16_t limit;
+    /**
          *                  base address of idt
          */
-        idt_gate* base;
-    } idtr = {
-        (sizeof(idt_gate) * idt.size()) - 1,
-        idt.begin()
-    };
+    idt_gate* base;
+} idtr = {
+    (sizeof(idt_gate) * idt.size()) - 1,
+    idt.begin()
+};
 
-    static_assert(10 == sizeof(idt_reg), "idt_reg size incorrect");
+static_assert(10 == sizeof(idt_reg), "idt_reg size incorrect");
 
-    void init() {
-        asm(
-            "lidt %0"
-            :
-            : "m"(idtr));
-    }
+void init() {
+    asm(
+        "lidt %0"
+        :
+        : "m"(idtr));
+}
 
-    /**
+/**
      *                      test int3
      */
-    void test_int() {
-        cursor crs{ color::white, color::black, 0, 0 };
-        crs << "testing interrupt";
-        asm volatile("int3");
-    }
+void test_int() {
+    cursor crs{ color::white, color::black, 0, 0 };
+    crs << "testing interrupt";
+    asm volatile("int3");
+}
 
-    // write different handlers for each irpt + exc later
-    // noreturn for testing purposes, will remove later
-    extern "C" __attribute__((noreturn)) void interrupt_handler() {
-        // cursor crs{ color::white, color::black, 0, 0 };
-        // crs << "\nINTERRUPT OCCURRED";
+// write different handlers for each irpt + exc later
+// noreturn for testing purposes, will remove later
+extern "C" __attribute__((noreturn)) void interrupt_handler() {
+    // cursor crs{ color::white, color::black, 0, 0 };
+    // crs << "\nINTERRUPT OCCURRED";
 
-        for (;;)
-            asm("hlt");
-    }
+    for (;;)
+        asm("hlt");
+}
 
-    extern "C" __attribute__((noreturn)) void exception_handler(interrupt_error error_code) {
-        (void)error_code;
+extern "C" __attribute__((noreturn)) void exception_handler(interrupt_error error_code) {
+    (void)error_code;
 
-        cursor crs{ color::white, color::black, 0, 0 };
-        crs << "\nEXCEPTION OCCURRED";
+    cursor crs{ color::white, color::black, 0, 0 };
+    crs << "\nEXCEPTION OCCURRED";
 
-        while (1)
-            ;
-    }
+    while (1)
+        ;
+}
 }  // namespace firefly::kernel::interrupt

--- a/arch/x86_64/kernel/kernel.cpp
+++ b/arch/x86_64/kernel/kernel.cpp
@@ -40,6 +40,85 @@ void write_ff_info() {
 }
 }  // namespace firefly::kernel::main
 
+int mprintf([[maybe_unused]] const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    [[maybe_unused]] int i = 0;
+    [[maybe_unused]] int len = strlen(fmt);
+    [[maybe_unused]] int res = 0;
+
+    for (; i < len; i++) {
+        switch (fmt[i]) {
+            case '%': {
+                switch (fmt[i + 1]) {
+                    case 'c': {
+                        char arg = va_arg(ap, int);
+                        firefly::libkern::print((char)arg);
+                        i += 2, ++res;
+                        break;
+                    }
+
+                    case 's': {
+                        char* arg = va_arg(ap, char*);
+                        firefly::libkern::print(arg);
+                        i += 2, (res += 2 + strlen(arg));
+                        break;
+                    }
+
+                    // case 'i':
+                    case 'd': {
+                        int arg = va_arg(ap, int);
+                        char buff[20];
+                        firefly::libkern::print(itoa(arg, buff, 10));
+                        res += digitcount(arg);
+                        i += 2;
+                        break;
+                    }
+
+                    case 'x': {
+                        int arg = va_arg(ap, int);
+                        char buff[20];
+                        firefly::libkern::print(itoa(arg, buff, 16));
+                        res += strlen(buff);
+                        i += 2;
+                        break;
+                    }
+                    // case 'X': {
+                    //     int arg = va_arg(ap, int);
+                    //     char buff[20];
+                    //     firefly::libkern::print(itoa(arg, buff, 16, true));
+                    //     res += strlen(buff);
+                    //     i += 2;
+                    //     break;
+                    // }
+
+                    // case 'b': {
+                    //     int arg = va_arg(ap, int);
+                    //     char buff[20];
+                    //     firefly::libkern::print("0b", itoa(arg, buff, 2));
+                    //     i += 2;
+                    //     break;
+                    // }
+
+                    // case 'o': {
+                    //     // int arg = va_arg(ap, int);
+                    //     // char buff[20];
+                    //     // firefly::libkern::print(itoa(arg, buff, 8));
+                    //     i += 2;
+                    //     break;
+                    // }
+                }
+            }
+            default:
+                firefly::libkern::print(fmt[i]);
+                va_end(ap);
+                res++;
+                break;
+        }
+    }
+    return res;
+}
+
 extern "C" [[noreturn]] void kernel_main(uint64_t magic, uint64_t mb2_proto_struct) {
     using firefly::drivers::vga::color;
     using firefly::drivers::vga::cursor;
@@ -51,6 +130,14 @@ extern "C" [[noreturn]] void kernel_main(uint64_t magic, uint64_t mb2_proto_stru
     firefly::kernel::interrupt::init();
     firefly::kernel::kernel_init(magic, mb2_proto_struct);
     
+    //Printf test
+    int res = printf("Hex: %x\n", 0xabc);
+    printf("%d chars were written\n", res);
+    printf("Address of res is: %X\n", &res);
+    printf("octal: %o\n", 100);
+    printf("long hex: 0x%x\n", 0xabcdef12);
+    
+
     while (true) {
         auto key = firefly::drivers::ps2::get_scancode();
         if (!key.has_value()) {

--- a/flags.mk
+++ b/flags.mk
@@ -35,6 +35,11 @@ CXX_FLAGS =						\
 	-fno-exceptions 			\
 	-fno-rtti 					\
 	-Wno-zero-length-array 		\
+	-mno-80387		            \
+    -mno-mmx					\
+    -mno-3dnow					\
+	-mno-sse                    \
+    -mno-sse2	                \
 	-Wno-gnu
 
 ASM_FLAGS = -f elf64 -g -F dwarf
@@ -48,7 +53,7 @@ CONV_FILES = $(CXX_FILES:.cpp=.cxx.o) $(ASM_FILES:.asm=.asm.o) # Convert file ex
 OBJ_FILES  = $(addprefix $(BUILD_DIR)/,$(CONV_FILES))
 
 ### STL BUILD FLAGS ####
-STL_CXX_FLAGS = -m64 -std=gnu++17 -Wall -Wextra -pedantic -Werror -g -O2 -nostdlib -fno-builtin -fno-PIC -mno-red-zone -fno-stack-check -fno-stack-protector -fno-omit-frame-pointer -ffreestanding -fno-exceptions -fno-rtti
+STL_CXX_FLAGS = -I ../ -Dx86_64 -m64 -std=gnu++17 -Wall -Wextra -pedantic -Werror -g -O2 -nostdlib -fno-builtin -fno-PIC -mno-red-zone -fno-stack-check -fno-stack-protector -fno-omit-frame-pointer -ffreestanding -fno-exceptions -fno-rtti
 
 # Note: We use . as paths are relative to the Makefile which included flags.mk
 STL_SRC_DIR = .
@@ -69,15 +74,17 @@ CXX_FLAGS =						\
 	-I./include/stl/			\
 	-target x86_64-unknown-elf	\
 	-m32						\
+	-O2							\
 	-mcmodel=kernel				\
 	-std=c++20   				\
 	-Wall						\
 	-Wextra 					\
 	-pedantic 					\
 	-Werror 					\
-	-g 							\
+	-g -pipe					\
 	-nostdlib 					\
 	-fno-builtin 				\
+	-fno-pie 					\
 	-fno-PIC 					\
 	-mno-red-zone 				\
 	-fno-stack-check 			\
@@ -87,6 +94,11 @@ CXX_FLAGS =						\
 	-fno-exceptions 			\
 	-fno-rtti 					\
 	-Wno-zero-length-array 		\
+	-mno-80387		            \
+    -mno-mmx					\
+    -mno-3dnow					\
+	-mno-sse                    \
+    -mno-sse2	                \
 	-Wno-gnu
 
 ASM_FLAGS = -f elf32 -g -F dwarf
@@ -101,7 +113,7 @@ CONV_FILES = $(CXX_FILES:.cpp=.cxx.o) $(ASM_FILES:.asm=.asm.o) # Convert file ex
 OBJ_FILES  = $(addprefix $(BUILD_DIR)/,$(CONV_FILES))
 
 ### STL BUILD FLAGS ####
-STL_CXX_FLAGS = -m32 -std=gnu++17 -Wall -Wextra -pedantic -Werror -g -O2 -nostdlib -fno-builtin -fno-PIC -mno-red-zone -fno-stack-check -fno-stack-protector -fno-omit-frame-pointer -ffreestanding -fno-exceptions -fno-rtti
+STL_CXX_FLAGS = -I ../ -DI386 -m32 -std=gnu++17 -Wall -Wextra -pedantic -Werror -g -O2 -nostdlib -fno-builtin -fno-PIC -mno-red-zone -fno-stack-check -fno-stack-protector -fno-omit-frame-pointer -ffreestanding -fno-exceptions -fno-rtti
 
 # Note: We use . as paths are relative to the Makefile which included flags.mk
 STL_SRC_DIR = .

--- a/include/i386/drivers/vga.hpp
+++ b/include/i386/drivers/vga.hpp
@@ -102,6 +102,9 @@ struct cursor {
      * @return cursor&      This cursor 
      */
     cursor& operator<<(int n);
+    cursor& operator<<(short n);
+    cursor& operator<<(long n);
+    cursor& operator<<(unsigned n);
 
     /**
      *                      Sets the default foreground color

--- a/include/i386/drivers/vga.hpp
+++ b/include/i386/drivers/vga.hpp
@@ -101,10 +101,11 @@ struct cursor {
      * @param n             The integer to print
      * @return cursor&      This cursor 
      */
-    cursor& operator<<(int n);
-    cursor& operator<<(short n);
-    cursor& operator<<(long n);
-    cursor& operator<<(unsigned n);
+    cursor& operator<<(size_t n);
+    //     cursor& operator<<(int n);
+    //     cursor& operator<<(short n);
+    //     cursor& operator<<(long n);
+    //     cursor& operator<<(unsigned n);
 
     /**
      *                      Sets the default foreground color

--- a/include/i386/int/interrupt.hpp
+++ b/include/i386/int/interrupt.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stl/cstdlib/cstdint.h>
+
+namespace firefly::kernel::core::interrupt {
+    void init();
+
+    // test interrupt handler
+    void test_int();
+
+    namespace change{ 
+        void update(uint32_t handler, uint16_t cs, uint8_t type, uint8_t index);
+    }
+
+}  // namespace firefly::kernel::interrupt

--- a/include/i386/libk++/ios.h
+++ b/include/i386/libk++/ios.h
@@ -3,12 +3,14 @@
 #include "cstdlib/stdio.h"
 
 namespace firefly::libkern {
-char buff[20];
-char* hex(int n) {
-    return itoa(n, buff, 16);
-}
+// static char buff[20];
+// char* hex(int n) {
+//     static char buff[20];
+//     return itoa(n, buff, 16);
+// }
 
-char* dec(int n) {
-    return itoa(n, buff, 10);
-}
+// char* dec(int n) {
+//     static char buff[20];
+//     return itoa(n, buff, 10);
+// }
 }  // namespace firefly::libkern

--- a/include/i386/libk++/iostream.h
+++ b/include/i386/libk++/iostream.h
@@ -24,7 +24,7 @@
 
 #define klog(...) ({                                                         \
     ((firefly::libkern::get_cursor_handle() << __FUNCTION__                  \
-                                            << ": " << __VA_ARGS__)); \
+                                            << ": " << __VA_ARGS__ << ' ')); \
 })
 
 namespace firefly::libkern {
@@ -38,7 +38,7 @@ const auto endl = '\n';
 
 template <typename... Tys>
 void print(Tys... args) {
-    ((firefly::libkern::get_cursor_handle() << ": " << args), ...);
+    ((firefly::libkern::get_cursor_handle() << args), ...);
 }
 
 }  // namespace firefly::libkern

--- a/include/i386/trace/strace.hpp
+++ b/include/i386/trace/strace.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void panic(const char *msg);

--- a/linkage/linker_x86_64.ld
+++ b/linkage/linker_x86_64.ld
@@ -3,7 +3,7 @@ ENTRY(start)
 VIRT_BASE = 0xFFFFFFFF80000000;
 
 SECTIONS {
-    . = 0x00100000;
+    . = 0x00200000;
 
     /* this is all used before mapping
        so give its labels physical addresses */


### PR DESCRIPTION
The i386 version of FireflyOS is now equal to x86_64 in terms of features and progress (the only thing the i386 doesn't have is a keyboard driver because I didn't see a point in adding one rn)

The i386 version also had some slight adjustments to the interrupt.cpp file