### PR TITLE
Fix anonymous non-C struct bug

### DIFF
--- a/include/x86_64/libk++/bitmap.h
+++ b/include/x86_64/libk++/bitmap.h
@@ -6,7 +6,7 @@
 #define BMP_BLOCK_SIZE 8
 
 namespace firefly::libkern {
-typedef struct
+typedef struct _bitmap_t
 {
     uint32_t* pool;
 } bitmap_t;
@@ -14,7 +14,7 @@ typedef struct
 constexpr int BIT_SET = 1;
 constexpr int BIT_CLEAR = 0;
 
-typedef struct
+typedef struct _bitmap_res_t
 {
     bool success;
     int64_t bit_offset; // Only used by get() & find_first()


### PR DESCRIPTION
Anonymous non-C structs aren't compatible with the C++ 20 standard. When compiled with clang-13, compilation fails unless I define the struct as a type.