### PR TITLE
Printf rewrite

### DIFF
--- a/firefly/libk++/fmt.cpp
+++ b/firefly/libk++/fmt.cpp
@@ -102,7 +102,7 @@ char buffer[512];
 int printf(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    vsnprintf((char*)&buffer, (size_t)511, fmt, ap);
+    vsnprintf(buffer, (size_t)512, fmt, ap);
     va_end(ap);
 
     firefly::kernel::device::stivale2_term::write(buffer);

--- a/firefly/libk++/fmt.cpp
+++ b/firefly/libk++/fmt.cpp
@@ -111,13 +111,20 @@ int printf(const char* fmt, ...) {
 }
 
 int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
+    size_t usedLen = 0;
+    auto append = [size, &usedLen, &str] (char ch) {
+        if (usedLen < size - 1)
+            *str++ = ch;
+        ++usedLen;
+    };
+
     while (*fmt != '\0') {
         switch (*fmt) {
             case '%': {
                 switch (*++fmt) {
                     case 'c': {
                         auto arg = va_arg(ap, int);
-                        *str++ = arg;
+                        append(arg);
                         break;
                     }
 
@@ -125,7 +132,7 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                         auto arg = va_arg(ap, char*);
                         size_t len = strlen(arg);
                         for (size_t j = 0; j < len; j++)
-                            *str++ = arg[j];
+                            append(arg[j]);
 
                         break;
                     }
@@ -134,14 +141,14 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                     case 'd': {
                         uint64_t arg = va_arg(ap, uint64_t);
                         if (arg == 0)
-                            *str++ = '0';
+                            append('0');
                         else {
                             char res[20];
                             itoa(arg, res, 10);
 
                             size_t len = strlen(res);
                             for (size_t j = 0; j < len; j++)
-                                *str++ = res[j];
+                                append(res[j]);
                         }
                         break;
                     }
@@ -149,14 +156,14 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                     case 'x': {
                         uint64_t arg = va_arg(ap, uint64_t);
                         if (arg == 0)
-                            *str++ = '0';
+                            append('0');
                         else {
                             char res[20];
                             itoa(arg, res, 16);
 
                             size_t len = strlen(res);
                             for (size_t j = 0; j < len; j++)
-                                *str++ = res[j];
+                                append(res[j]);
                         }
                         break;
                     }
@@ -165,13 +172,13 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                         uint64_t arg = va_arg(ap, uint64_t);
                         char res[20];
                         if (arg == 0)
-                            *str++ = '0';
+                            append('0');
                         else {
                             itoa(arg, res, 16, true);
 
                             size_t len = strlen(res);
                             for (size_t j = 0; j < len; j++)
-                                *str++ = res[j];
+                                append(res[j]);
                         }
                         break;
                     }
@@ -181,13 +188,14 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
             }
 
             default:
-                *str++ = *fmt;
+                append(*fmt);
                 break;
         }
         ++fmt;
     }
-    *str = '\0';
+    if (size != 0 && str)
+        *str = '\0';
 
-    return 0;
+    return usedLen;
 }
 }  // namespace firefly::libkern::fmt

--- a/firefly/libk++/fmt.cpp
+++ b/firefly/libk++/fmt.cpp
@@ -102,9 +102,11 @@ char buffer[512];
 int printf(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    vsnprintf(buffer, (size_t)512, fmt, ap);
+    size_t outLen = vsnprintf(buffer, sizeof(buffer), fmt, ap);
     va_end(ap);
 
+    if (outLen >= sizeof(buffer))
+        return -1;
     firefly::kernel::device::stivale2_term::write(buffer);
 
     return 0;

--- a/firefly/libk++/fmt.cpp
+++ b/firefly/libk++/fmt.cpp
@@ -1,6 +1,7 @@
 #include "libk++/fmt.hpp"
 
 #include "firefly/console/stivale2-term.hpp"
+#include "cstdlib/cassert.h"
 
 namespace firefly::libkern::fmt {
 
@@ -113,6 +114,8 @@ int printf(const char* fmt, ...) {
 }
 
 int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
+    assert(fmt != nullptr);
+    assert(size == 0 || str != nullptr);
     size_t usedLen = 0;
     auto append = [size, &usedLen, &str] (char ch) {
         if (usedLen < size - 1)

--- a/firefly/libk++/fmt.cpp
+++ b/firefly/libk++/fmt.cpp
@@ -111,13 +111,12 @@ int printf(const char* fmt, ...) {
 }
 
 int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
-    for (size_t i = 0; i < size; i++) {
-        switch (fmt[i]) {
+    while (*fmt != '\0') {
+        switch (*fmt) {
             case '%': {
-                switch (fmt[i + 1]) {
+                switch (*++fmt) {
                     case 'c': {
                         auto arg = va_arg(ap, int);
-                        i++;
                         *str++ = arg;
                         break;
                     }
@@ -128,7 +127,6 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                         for (size_t j = 0; j < len; j++)
                             *str++ = arg[j];
 
-                        i++;
                         break;
                     }
 
@@ -145,7 +143,6 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                             for (size_t j = 0; j < len; j++)
                                 *str++ = res[j];
                         }
-                        i++;
                         break;
                     }
 
@@ -161,7 +158,6 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                             for (size_t j = 0; j < len; j++)
                                 *str++ = res[j];
                         }
-                        i++;
                         break;
                     }
 
@@ -177,7 +173,6 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
                             for (size_t j = 0; j < len; j++)
                                 *str++ = res[j];
                         }
-                        i++;
                         break;
                     }
                 }
@@ -186,11 +181,12 @@ int vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
             }
 
             default:
-                *str++ = fmt[i];
+                *str++ = *fmt;
                 break;
         }
+        ++fmt;
     }
-    *str++ = '\0';
+    *str = '\0';
 
     return 0;
 }

--- a/include/firefly/logger.hpp
+++ b/include/firefly/logger.hpp
@@ -49,8 +49,10 @@ public:
     const char *format(const char *fmt, ...) {
         va_list ap;
         va_start(ap, fmt);
-        libkern::fmt::vsnprintf((char *)&buffer, (size_t)511, fmt, ap);
+        size_t outLen = libkern::fmt::vsnprintf(buffer, sizeof(buffer), fmt, ap);
         va_end(ap);
+        if (outLen >= sizeof(buffer))
+            return nullptr;
 
         return const_cast<char *>(buffer);
     }


### PR DESCRIPTION
Fixed up a bug in vsnprintf, slightly reworked to be more standard compliant

size argument accounts for null byte so caller doesn't have to
returns length of string, including truncated bytes if it would overflow